### PR TITLE
Merge 0.1.2 release commit & fix premature drop of prog code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpf"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Frank Denis <github@pureftpd.org>"]
 description = "Attach BPF filters"
 license = "ISC"
@@ -13,5 +13,4 @@ edition = "2018"
 travis-ci = { repository = "jedisct1/rust-bpf" }
 
 [dependencies]
-clippy = {version = "~0", optional = true}
-libc = "~0.2"
+libc = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#![cfg_attr(feature = "clippy", feature(plugin))]
-#![cfg_attr(feature = "clippy", plugin(clippy))]
-
 #[cfg(target_os = "linux")]
 pub use bpf_linux::*;
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Hello, thank you for rust-bpf! It's come in handy for a number of my projects.

`Prog::new` takes ownership of the `Vec<Op>` but doesn't retain ownership or a reference so it'll be dropped at the end of `new` and the pointer will become invalid. I discovered this because calls to `bpf::attach_filter` were failing with `EINVAL`, probably because the memory was overwritten with other values.

I've gone with this ugly fix to avoid changing the interface. 